### PR TITLE
Obfuscate Destination Secrets

### DIFF
--- a/server/lib/ingest/destinations.ex
+++ b/server/lib/ingest/destinations.ex
@@ -142,7 +142,37 @@ defmodule Ingest.Destinations do
       ** (Ecto.NoResultsError)
 
   """
-  def get_destination!(id), do: Repo.get!(Destination, id)
+  def get_destination!(id) do
+    destination = Repo.get!(Destination, id)
+
+    destination_without_sensitive_data =
+      case destination.type do
+        :s3 ->
+          %{
+            destination
+            | s3_config: %{destination.s3_config | access_key_id: nil, secret_access_key: nil}
+          }
+
+        :azure ->
+          %{
+            destination
+            | azure_config: %{destination.azure_config | account_name: nil, account_key: nil}
+          }
+
+        :lakefs ->
+          %{
+            destination
+            | lakefs_config: %{
+                destination.lakefs_config
+                | access_key_id: nil,
+                  secret_access_key: nil
+              }
+          }
+
+        _ ->
+          destination
+      end
+  end
 
   @doc """
   Creates a destination.

--- a/server/lib/ingest/destinations/destination.ex
+++ b/server/lib/ingest/destinations/destination.ex
@@ -70,7 +70,7 @@ defmodule Ingest.Destinations.S3Config do
       :final_path,
       :ssl
     ])
-    |> validate_required([:access_key_id, :secret_access_key, :bucket, :path])
+    |> validate_required([:bucket, :path])
   end
 end
 
@@ -95,7 +95,7 @@ defmodule Ingest.Destinations.AzureConfig do
   def changeset(config, attrs) do
     config
     |> cast(attrs, [:account_name, :account_key, :base_url, :container, :path, :ssl, :final_path])
-    |> validate_required([:account_name, :account_key, :container])
+    |> validate_required([:container])
   end
 end
 
@@ -128,7 +128,7 @@ defmodule Ingest.Destinations.LakeFSConfig do
       :ssl,
       :region
     ])
-    |> validate_required([:access_key_id, :secret_access_key, :base_url, :repository])
+    |> validate_required([:base_url, :repository])
   end
 end
 

--- a/server/lib/ingest_web/components_live/destination_form.ex
+++ b/server/lib/ingest_web/components_live/destination_form.ex
@@ -75,7 +75,7 @@ defmodule IngestWeb.LiveComponents.DestinationForm do
           </div>
 
           <div
-            :if={@type == "s3"}
+            :if={@type == "s3" and assigns.live_action == :new}
             class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
           >
             <div>
@@ -93,12 +93,71 @@ defmodule IngestWeb.LiveComponents.DestinationForm do
                   <.label for="status-select">
                     Access Key ID
                   </.label>
-                  <.input type="text" value={nil} field={config[:access_key_id]} />
+                  <.input type="text" field={config[:access_key_id]} />
 
                   <.label for="status-select">
                     Secret Access Key
                   </.label>
-                  <.input type="text" value={nil} field={config[:secret_access_key]} />
+                  <.input type="text" field={config[:secret_access_key]} />
+
+                  <.label for="status-select">
+                    URL
+                  </.label>
+                  <.input type="text" field={config[:base_url]} />
+
+                  <.label for="status-select">
+                    Bucket
+                  </.label>
+                  <.input type="text" field={config[:bucket]} />
+
+                  <.label for="status-select">
+                    Region
+                  </.label>
+                  <.input type="text" field={config[:region]} />
+
+                  <.label for="status-select">
+                    Root Path
+                  </.label>
+                  <.input type="text" field={config[:path]} />
+                </.inputs_for>
+              </div>
+            </div>
+          </div>
+          <div
+            :if={@type == "s3" and assigns.live_action == :edit}
+            class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
+          >
+            <div>
+              <h2 class="text-base font-semibold leading-7 text-gray-900">
+                AWS S3 Credentials
+              </h2>
+              <p class="mt-1 text-sm leading-6 text-gray-600">
+                Your AWS S3 credentials for the data's location after it's been uploaded by the user.
+              </p>
+            </div>
+
+            <div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+              <div class="sm:col-span-4">
+                <.inputs_for :let={config} field={@destination_form[:s3_config]}>
+                  <.label for="status-select">
+                    Access Key ID
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
+
+                  <.label for="status-select">
+                    Secret Access Key
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
 
                   <.label for="status-select">
                     URL
@@ -125,7 +184,7 @@ defmodule IngestWeb.LiveComponents.DestinationForm do
           </div>
 
           <div
-            :if={@type == "lakefs"}
+            :if={@type == "lakefs" and assigns.live_action == :new}
             class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
           >
             <div>
@@ -210,7 +269,102 @@ defmodule IngestWeb.LiveComponents.DestinationForm do
           </div>
 
           <div
-            :if={@type == "azure"}
+            :if={@type == "lakefs" and assigns.live_action == :edit}
+            class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
+          >
+            <div>
+              <h2 class="text-base font-semibold leading-7 text-gray-900">
+                LakeFS Credentials
+              </h2>
+              <p class="mt-1 text-sm leading-6 text-gray-600">
+                Your LakeFS credentials - make sure that you have sufficient permissions to work with the repository you choose.
+              </p>
+            </div>
+
+            <div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+              <div class="sm:col-span-4">
+                <.inputs_for :let={config} field={@destination_form[:lakefs_config]}>
+                  <.label for="status-select">
+                    Access Key ID
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
+
+                  <.label for="status-select">
+                    Secret Access Key
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
+
+                  <.label for="status-select">
+                    URL
+                  </.label>
+                  <.input type="text" field={config[:base_url]} />
+                  <p class="text-xs">
+                    Leave the trailing / off the url.
+                  </p>
+
+                  <.label for="status-select">
+                    Port
+                  </.label>
+                  <.input type="text" field={config[:port]} />
+                  <p class="text-xs">
+                    When in doubt, leave blank.
+                  </p>
+
+                  <.label for="status-select">
+                    SSL
+                  </.label>
+                  <.input type="checkbox" field={config[:ssl]} />
+                  <p class="text-xs">
+                    When in doubt, enable this setting.
+                  </p>
+
+                  <.button
+                    class="rounded-md bg-indigo-600 px-3 py-2 mt-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    phx-disable-with="Saving..."
+                    name="save"
+                    value="test_connection"
+                  >
+                    Test Connection
+                  </.button>
+
+                  <.label for="status-select">
+                    Repositories
+                  </.label>
+                  <.input
+                    :if={@lakefs_repos != [] || config[:repository]}
+                    type="select"
+                    options={
+                      if @destination.lakefs_config do
+                        [
+                          @destination.lakefs_config.repository
+                          | @lakefs_repos |> Enum.map(fn r -> r["id"] end)
+                        ]
+                      else
+                        @lakefs_repos |> Enum.map(fn r -> r["id"] end)
+                      end
+                    }
+                    field={config[:repository]}
+                  />
+                </.inputs_for>
+                <p :if={@lakefs_repos == []} class="text-xs">
+                  Test connection to load repositories for selection
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            :if={@type == "azure" and assigns.live_action == :new}
             class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
           >
             <div>
@@ -237,6 +391,89 @@ defmodule IngestWeb.LiveComponents.DestinationForm do
                     Account Key
                   </.label>
                   <.input type="text" field={config[:account_key]} />
+                  <p class="text-xs">
+                    This field is stored in an encrypted state and will not be made available to other users of the destination
+                  </p>
+
+                  <.label for="status-select">
+                    Base Service URL
+                  </.label>
+                  <.input type="text" field={config[:base_url]} />
+                  <p class="text-xs">
+                    Leave blank to use the service's default option.
+                  </p>
+
+                  <.label for="status-select">
+                    SSL
+                  </.label>
+                  <.input type="checkbox" field={config[:ssl]} />
+                  <p class="text-xs">
+                    When in doubt, enable this setting.
+                  </p>
+
+                  <.label for="status-select">
+                    Container
+                  </.label>
+                  <.input type="text" field={config[:container]} />
+
+                  <.label for="status-select">
+                    Staging Path
+                  </.label>
+                  <.input type="text" field={config[:path]} />
+                  <p class="text-xs">
+                    Where data should be put while awaiting metadata entry and any modification by the request owner.
+                  </p>
+
+                  <.label for="status-select">
+                    Final Path
+                  </.label>
+                  <.input type="text" field={config[:final_path]} />
+                  <p class="text-xs">
+                    Where data should be put once all tasks and modifications are complete. Once data is put here, it can no longer be manipulated by Ingest.
+                  </p>
+                </.inputs_for>
+              </div>
+            </div>
+          </div>
+
+          <div
+            :if={@type == "azure" and assigns.live_action == :edit}
+            class="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3"
+          >
+            <div>
+              <h2 class="text-base font-semibold leading-7 text-gray-900">
+                Azure Data Lake Credentials
+              </h2>
+              <p class="mt-1 text-sm leading-6 text-gray-600">
+                Your Azure credentials for the data's location after it's been uploaded by the user, and before you review and potentially modify it.
+              </p>
+            </div>
+
+            <div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+              <div class="sm:col-span-4">
+                <.inputs_for :let={config} field={@destination_form[:azure_config]}>
+                  <.label for="status-select">
+                    Account Name
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
+                  <p class="text-xs">
+                    This field is stored in an encrypted state and will not be made available to other users of the destination
+                  </p>
+
+                  <.label for="status-select">
+                    Account Key
+                  </.label>
+                  <input
+                    disabled
+                    type="password"
+                    value="************"
+                    class="rounded border-zinc-300 text-zinc-900 focus:ring-0  disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+                  />
                   <p class="text-xs">
                     This field is stored in an encrypted state and will not be made available to other users of the destination
                   </p>


### PR DESCRIPTION
# Motivation

This PR involves the obfuscation of destination secrets, which ensures that they are write-only. Users won't be able to view these secrets after they have been set. If users need to modify the secrets, they would have to create a new destination. 