### PR TITLE
Template field checkbox for naming convention.

### DIFF
--- a/server/apps/ingest/lib/ingest/requests.ex
+++ b/server/apps/ingest/lib/ingest/requests.ex
@@ -57,13 +57,6 @@ defmodule Ingest.Requests do
   """
   def get_template!(id), do: Repo.get!(Template, id) |> Repo.preload(:template_members)
 
-  def get_name_fields!(id) do
-    fields = Repo.get!(Template, id).fields
-    filtered = Enum.filter(fields, fn d -> d.namer == true end)
-    test = Enum.map(filtered, fn d -> d.label end)
-    test
-  end
-
   @doc """
   Creates a template.
 

--- a/server/apps/ingest/lib/ingest/requests.ex
+++ b/server/apps/ingest/lib/ingest/requests.ex
@@ -57,6 +57,13 @@ defmodule Ingest.Requests do
   """
   def get_template!(id), do: Repo.get!(Template, id) |> Repo.preload(:template_members)
 
+  def get_name_fields!(id) do
+    fields = Repo.get!(Template, id).fields
+    filtered = Enum.filter(fields, fn(d) -> d.namer == true end)
+    test = Enum.map(filtered, fn(d) -> d.label end)
+    test
+  end
+
   @doc """
   Creates a template.
 

--- a/server/apps/ingest/lib/ingest/requests.ex
+++ b/server/apps/ingest/lib/ingest/requests.ex
@@ -59,8 +59,8 @@ defmodule Ingest.Requests do
 
   def get_name_fields!(id) do
     fields = Repo.get!(Template, id).fields
-    filtered = Enum.filter(fields, fn(d) -> d.namer == true end)
-    test = Enum.map(filtered, fn(d) -> d.label end)
+    filtered = Enum.filter(fields, fn d -> d.namer == true end)
+    test = Enum.map(filtered, fn d -> d.label end)
     test
   end
 

--- a/server/apps/ingest/lib/ingest/requests/template.ex
+++ b/server/apps/ingest/lib/ingest/requests/template.ex
@@ -111,6 +111,7 @@ defmodule Ingest.Requests.TemplateField do
     # the map has two keys, template and name
     field :branch_options, {:array, :map}, default: []
     field :required, :boolean
+    field :namer, :boolean
     field :file_extensions, {:array, :string}
   end
 
@@ -123,6 +124,7 @@ defmodule Ingest.Requests.TemplateField do
       :select_options,
       :branch_options,
       :required,
+      :namer,
       :file_extensions
     ])
     |> validate_required([:label, :type])

--- a/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/request_show_live.ex
+++ b/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/request_show_live.ex
@@ -499,6 +499,27 @@ defmodule IngestWeb.RequestShowLive do
         <!-- STATUS -->
       </div>
 
+      <!-- Start Name Section -->
+      <div class="grid grid-cols-1">
+        <div>
+          <!-- Start Header -->
+          <div class="relative mt-10">
+            <div class="absolute inset-0 flex items-center" aria-hidden="true">
+              <div class="w-full border-t border-gray-300"></div>
+            </div>
+            <div class="relative flex justify-center">
+              <span class="bg-white px-3 text-base font-semibold leading-6 text-gray-900">
+                File Naming Convention
+              </span>
+            </div>
+          </div>
+          <!-- End Header -->
+
+        </div>
+
+      </div>
+      <!-- End Name Section -->
+
       <div class="grid grid-cols-1">
         <!-- DESTINATIONS -->
         <div>

--- a/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/request_show_live.ex
+++ b/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/request_show_live.ex
@@ -498,8 +498,8 @@ defmodule IngestWeb.RequestShowLive do
         </div>
         <!-- STATUS -->
       </div>
-
-      <!-- Start Name Section -->
+      
+    <!-- Start Name Section -->
       <div class="grid grid-cols-1">
         <div>
           <!-- Start Header -->
@@ -516,7 +516,6 @@ defmodule IngestWeb.RequestShowLive do
           <!-- End Header -->
 
         </div>
-
       </div>
       <!-- End Name Section -->
 

--- a/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/template_builder_live.ex
+++ b/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/template_builder_live.ex
@@ -305,11 +305,11 @@ defmodule IngestWeb.TemplateBuilderLive do
             </div>
             <%= if @field_form[:required].value == true do %>
               <div id="naming_convention" class="sm:col-span-4 py-3">
-                <label for="namer" class="block text-sm font-medium leading-6 text-white">
+                <label for="name_field" class="block text-sm font-medium leading-6 text-white">
                   Used In Naming Convention
                 </label>
                 <div class="mt-2">
-                  <.input type="checkbox" field={@field_form[:namer]} />
+                  <.input type="checkbox" field={@field_form[:name_field]} />
                 </div>
                 <p class="mt-3 text-sm leading-6 text-gray-400">
                   Whether or not this field will be used in the naming convention for data uploads.
@@ -398,7 +398,7 @@ defmodule IngestWeb.TemplateBuilderLive do
   def handle_params(%{"field_id" => field_id}, _uri, socket) do
     template = Requests.get_template!(socket.assigns.template.id)
     field = Enum.find(template.fields, fn field -> field.id == field_id end)
-    #Fires when you select anew field.
+    # Fires when you select anew field.
 
     {:noreply,
      socket
@@ -454,9 +454,9 @@ defmodule IngestWeb.TemplateBuilderLive do
       field_params
       |> Map.replace("file_extensions", String.split(file_extensions, ","))
       |> Map.put(
-        "namer",
+        "name_field",
         case is_required do
-          true -> field_params["namer"]
+          true -> field_params["name_field"]
           false -> false
         end
       )
@@ -465,7 +465,6 @@ defmodule IngestWeb.TemplateBuilderLive do
       socket.assigns.field
       |> Ingest.Requests.change_template_field(field_params)
       |> Map.put(:action, :validate)
-
 
     if String.to_existing_atom(type) != socket.assigns.field.type do
       {:noreply, socket |> save_field(field_params)}

--- a/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/template_builder_live.ex
+++ b/server/apps/ingest_web/lib/ingest_web/live/dashboard_live/template_builder_live.ex
@@ -1,6 +1,6 @@
 defmodule IngestWeb.TemplateBuilderLive do
   use IngestWeb, :live_view
-
+  require Logger
   alias Ingest.Requests
 
   @impl true
@@ -25,9 +25,10 @@ defmodule IngestWeb.TemplateBuilderLive do
         <h3 class="text-base font-semibold leading-6 text-gray-900">Form Builder</h3>
       </div>
     </div>
-
-    <div class="flex flex-row">
-      <div class="basis-1/3">
+<!-- Start field wrap -->
+    <div class="flex flex-row bg-red-300">
+    <!-- Start field list -->
+      <div class="basis-1/3 bg-green-300">
         <.link
           patch={~p"/dashboard/templates/#{@template.id}/new"}
           type="button"
@@ -103,7 +104,8 @@ defmodule IngestWeb.TemplateBuilderLive do
           </li>
         </ul>
       </div>
-
+      <!-- end field list -->
+      <!-- Start field creator -->
       <div :if={!@field} class="bg-gray-800 p-8 basis-2/3 h-screen ml-10">
         <div class="text-center">
           <svg
@@ -294,10 +296,23 @@ defmodule IngestWeb.TemplateBuilderLive do
                     Required
                   </label>
                   <div class="mt-2">
-                    <.input type="checkbox" field={@field_form[:required]} />
+                  <.input type="checkbox" field={@field_form[:required]} phx-click={required_clicked()}/>
                   </div>
                   <p class="mt-3 text-sm leading-6 text-gray-400">
                     Whether or not a user is required to fill the field before submitting.
+                  </p>
+                </div>
+              <%!-- </fieldset>
+              <fieldset> --%>
+                <div id="naming_convention" class="hidden sm:col-span-4 py-3">
+                  <label for="name" class="block text-sm font-medium leading-6 text-white">
+                    Used In Naming Convention
+                  </label>
+                  <div class="mt-2">
+                    <.input type="checkbox" field={@field_form[:namer]} />
+                  </div>
+                  <p class="mt-3 text-sm leading-6 text-gray-400">
+                    Whether or not field will be used in the naming convention for data uploads.
                   </p>
                 </div>
               </fieldset>
@@ -380,11 +395,30 @@ defmodule IngestWeb.TemplateBuilderLive do
      |> assign(:section, "templates"), layout: {IngestWeb.Layouts, :dashboard}}
   end
 
+  # @impl true
+  # def handle_event("toggle_required", _params, socket) do
+  #   Logger.info(socket.assigns.field_form[:required].value)
+  #   Logger.info(_params)
+  #   JS.toggle_class("hidden", to: "#naming_convention")
+  #   required = !socket.assigns.field_form[:required].value
+  #   field_form = Map.put(socket.assigns.field_form, :required, %{value: required})
+  #   {:noreply, assign(socket, :field_form, field_form)}
+  # end
+
+  def required_clicked() do
+    JS.toggle_class("hidden", to: "#naming_convention")
+    # check = document.getElementById("naming_convention")
+
+  end
+
+
+
   @impl true
   def handle_params(%{"field_id" => field_id}, _uri, socket) do
     template = Requests.get_template!(socket.assigns.template.id)
     field = Enum.find(template.fields, fn field -> field.id == field_id end)
-
+    Logger.info("This fires when you select a new field")
+    Logger.info(field)
     {:noreply,
      socket
      |> assign(:field, field)
@@ -396,6 +430,7 @@ defmodule IngestWeb.TemplateBuilderLive do
 
   @impl true
   def handle_params(_params, _uri, socket) do
+    Logger.info("This handle params _params is firing")
     {:noreply, socket |> assign(:field, nil)}
   end
 
@@ -433,6 +468,9 @@ defmodule IngestWeb.TemplateBuilderLive do
   def handle_event("validate", %{"template_field" => field_params}, socket) do
     %{"file_extensions" => file_extensions, "type" => type} = field_params
 
+    Logger.info("This fires when you change any of the parameters aside from the field type")
+    Logger.info(field_params["required"])
+
     field_params =
       field_params |> Map.replace("file_extensions", file_extensions |> String.split(","))
 
@@ -455,6 +493,8 @@ defmodule IngestWeb.TemplateBuilderLive do
         socket
       ) do
     %{"file_extensions" => file_extensions} = field_params
+
+
 
     field_params =
       field_params


### PR DESCRIPTION
Created another field parameter to specify whether field is used in naming convention. Name param checkbox only visible when field is required. If required is unchecked, the naming convention checkbox is removed and the parameter for that is also unselected to ensure only required fields are allowed in the naming convention.