### PR TITLE
AX-653: User permissions to update project roles.

### DIFF
--- a/lib/ingest/accounts/user.ex
+++ b/lib/ingest/accounts/user.ex
@@ -187,4 +187,12 @@ defmodule Ingest.Accounts.User do
       add_error(changeset, :current_password, "is not valid")
     end
   end
+
+  def is_admin?(%Ingest.Accounts.User{roles: roles}) when is_list(roles) do
+    :admin in roles
+  end
+
+  def is_admin?(%Ingest.Accounts.User{roles: role}) do
+    role == :admin
+  end
 end

--- a/lib/ingest/accounts/user/utils.ex
+++ b/lib/ingest/accounts/user/utils.ex
@@ -1,0 +1,17 @@
+defmodule Ingest.Accounts.User.Utils do
+  @moduledoc """
+  This module contains user predicates for permission evaluations.
+  """
+  alias Ingest.Accounts.User
+  alias Ingest.Repo
+
+  def user_may_update_project_role?(user, project) do
+    roles = for project_role <- (
+      Repo.get(User, user.id)
+      |> Repo.preload(:project_roles)
+    ).project_roles, into: %{} do
+      {project_role.project_id, project_role.role}
+    end
+    user.roles == :admin or roles[project.id] == :owner
+  end
+end

--- a/lib/ingest/destinations.ex
+++ b/lib/ingest/destinations.ex
@@ -129,7 +129,6 @@ defmodule Ingest.Destinations do
   end
 
   def list_own_destinations(%User{} = user) do
-
     query =
       from d in Destination,
         left_join: dm in DestinationMembers,
@@ -176,7 +175,6 @@ defmodule Ingest.Destinations do
 
   def get_destination_member!(id) do
 
-    Logger.info("GET DESTINAITON MEMBERS IS CALLED #{id}")
     member = Repo.get!(DestinationMembers, id)
 
     destination_query =
@@ -432,6 +430,7 @@ defmodule Ingest.Destinations do
         %DestinationMembers{} = member,
         config
       ) do
+
     {updated_r, _d} =
       if member.request_id do
         from(rd in Ingest.Requests.RequestDestination,

--- a/lib/ingest/lakefs.ex
+++ b/lib/ingest/lakefs.ex
@@ -100,21 +100,6 @@ defmodule Ingest.LakeFS do
     end
   end
 
-  # @doc """
-  # Creates a new branch for the repository. Will error if the branch exists
-  # """
-  # def create_branch(%__MODULE__{} = client, repository, name, source \\ "main") do
-  #   case Req.post(client.base_req,
-  #          url: "/api/v1/repositories/#{URI.encode(repository)}/branches",
-  #          json: %{
-  #            name: name,
-  #            source: source
-  #          }
-  #        ) do
-  #     {:ok, %{status: 201}} -> {:ok, nil}
-  #     {:error, res} -> {:error, res}
-  #   end
-  # end
   @doc """
   Creates a new branch for the repository.
   Returns:

--- a/lib/ingest_web/live/dashboard_live/project_show_live.ex
+++ b/lib/ingest_web/live/dashboard_live/project_show_live.ex
@@ -468,22 +468,6 @@ defmodule IngestWeb.ProjectShowLive do
       Ingest.Destinations.list_destination_members(destination)
       |> Enum.find(fn member -> to_string(member.project_id) == to_string(project.id) end)
 
-    destination_member =
-      if is_nil(destination_member) and Ingest.Accounts.User.is_admin?(socket.assigns.current_user) do
-        %Ingest.Destinations.DestinationMembers{
-          id: -1,
-          user_id: socket.assigns.current_user.id,
-          project_id: project.id,
-          destination_id: destination.id,
-          role: :admin,
-          status: :accepted,
-          email: socket.assigns.current_user.email,
-          request_id: nil
-        }
-      else
-        destination_member
-      end
-
     {:noreply,
      socket
      |> assign(:destination, destination)

--- a/lib/ingest_web/live/dashboard_live/project_show_live.ex
+++ b/lib/ingest_web/live/dashboard_live/project_show_live.ex
@@ -406,7 +406,7 @@ defmodule IngestWeb.ProjectShowLive do
         module={IngestWeb.LiveComponents.DestinationAddtionalConfigForm}
         id="share-destination-modal-component"
         current_user={@current_user}
-        patch={JS.patch(~p"/dashboard/projects/#{@project}")}
+        patch={~p"/dashboard/projects/#{@project}"}
       />
     </.modal>
 

--- a/lib/ingest_web/live/dashboard_live/project_show_live.ex
+++ b/lib/ingest_web/live/dashboard_live/project_show_live.ex
@@ -476,7 +476,9 @@ defmodule IngestWeb.ProjectShowLive do
           project_id: project.id,
           destination_id: destination.id,
           role: :admin,
-          status: :virtual
+          status: :accepted,
+          email: socket.assigns.current_user.email,
+          request_id: nil
         }
       else
         destination_member

--- a/lib/ingest_web/live/dashboard_live/projects_live.ex
+++ b/lib/ingest_web/live/dashboard_live/projects_live.ex
@@ -146,9 +146,11 @@ defmodule IngestWeb.ProjectsLive do
      |> stream_configure(:projects, dom_id: &elem(&1, 0).id)
      |> stream(
        :projects,
-       Ingest.Projects.list_own_projects_with_count(socket.assigns.current_user.id)
+       Projects.list_all_projects_with_count()
      )
-     |> apply_action(socket.assigns.live_action, params), layout: {IngestWeb.Layouts, :dashboard}}
+     |> apply_action(socket.assigns.live_action, params),
+     layout: {IngestWeb.Layouts, :dashboard}
+    }
   end
 
   @impl true

--- a/lib/ingest_web/live/dashboard_live/upload_show_live.ex
+++ b/lib/ingest_web/live/dashboard_live/upload_show_live.ex
@@ -140,6 +140,8 @@ defmodule IngestWeb.UploadShowLive do
   def mount(%{"id" => id}, _session, socket) do
     request = Requests.get_request!(id)
 
+    destinations = request.destinations ++ request.project.destinations
+
     classifications_allowed =
       (request.destinations ++ request.project.destinations)
       |> Enum.map(fn d -> d.classifications_allowed end)
@@ -182,6 +184,8 @@ defmodule IngestWeb.UploadShowLive do
   end
 
   defp handle_progress(:files, entry, socket) do
+    Logger.info("IS HANDLE PROGRESS FIRIN?????? BY GOD I HOPE SO ---------------------#{inspect(entry)}")
+
     if entry.done? do
       # meta should have the information for the destination and the location of the file
       # in the destination. We need to extract the information from the meta and then
@@ -225,6 +229,7 @@ defmodule IngestWeb.UploadShowLive do
 
   @impl true
   def handle_event("validate", _params, socket) do
+
     {:noreply, socket}
   end
 


### PR DESCRIPTION
This PR ensures that project roles may only be updated by admins and project owners. Other users on a project can see their own roles, but may not update them.

- [x] Admins should be able to change other user's roles regardless of project.
- [x] Project owners should be able to change other user's roles within the projects they own.
- [x] Other users should not be able to change their roles.